### PR TITLE
pointing to the latest library version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage
 Add a dependency to your `build.gradle`:
 
     dependencies {
-    compile 'com.sa90.infiniterecyclerview:library:1.0'
+    compile 'com.sa90.infiniterecyclerview:library:1.1'
 }
 
 and replace your recycler view with:


### PR DESCRIPTION
The README indicated that `1.0` is the latest release,
however, there is a newer version, `1.1`, with fixes for
the 'shouldLoadMore' bug I encountered in `1.0`.