### PR TITLE
added a performant way to notify when more data is loaded

### DIFF
--- a/library/src/main/java/com/sa90/infiniterecyclerview/InfiniteAdapter.java
+++ b/library/src/main/java/com/sa90/infiniterecyclerview/InfiniteAdapter.java
@@ -22,7 +22,7 @@ public abstract class InfiniteAdapter<VH extends RecyclerView.ViewHolder> extend
     @Override
     public final int getItemCount() {
         int actualCount = getCount();
-        if(getCount() == 0 || !shouldLoadMore)
+        if(actualCount == 0 || !shouldLoadMore)
             return actualCount;
         else
             return actualCount + 1;
@@ -42,11 +42,7 @@ public abstract class InfiniteAdapter<VH extends RecyclerView.ViewHolder> extend
     }
 
     private boolean isLoadingView(int position) {
-        boolean value = false;
-        if(position == getCount() && shouldLoadMore)
-            value = true;
-
-        return value;
+        return position == getCount() && shouldLoadMore;
     }
 
     public void setShouldLoadMore(boolean shouldLoadMore) {

--- a/library/src/main/java/com/sa90/infiniterecyclerview/InfiniteRecyclerView.java
+++ b/library/src/main/java/com/sa90/infiniterecyclerview/InfiniteRecyclerView.java
@@ -108,6 +108,19 @@ public class InfiniteRecyclerView extends RecyclerView {
     }
 
     /**
+     * This informs the RecyclerView that <code>itemCount</code> more data has been loaded,
+     * starting from <code>positionStart</code>
+     *
+     * This also calls the attached adapter's {@link RecyclerView.Adapter#notifyItemRangeInserted(int, int)} method,
+     * so the implementing class only needs to call this method
+     */
+    @SuppressWarnings("unused")
+    public void moreDataLoaded(int positionStart, int itemCount) {
+        loading = false;
+        mAdapter.notifyItemRangeInserted(positionStart, itemCount);
+    }
+
+    /**
      * Set as false when you don't want the recycler view to load more data. This will also remove the loading view
      * @param loadMore
      */


### PR DESCRIPTION
Using [RecyclerView.Adapter#notifyDataSetChanged()](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.Adapter.html#notifyDataSetChanged()) is not very good for
performance, as the view has to rebind all the items.
An overload for `InfiniteRecyclerView#moreDataLoaded()` has
been added to use [RecyclerView.Adapter#notifyItemRangeInserted(int, int)](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.Adapter.html#notifyItemRangeInserted(int,%20int))
instead.